### PR TITLE
Standalone problem

### DIFF
--- a/statements/olymp.sty
+++ b/statements/olymp.sty
@@ -401,6 +401,7 @@
 % -- End of no feedback case --
 
     {
+        \ifdefined\NoProblemHead\else%
         \noindent
         \refstepcounter{problem}
         \textbf{\problemheadfont\textsf{%
@@ -448,6 +449,7 @@
         }
         \nopagebreak
         \par\vspace{\afterconstraints}
+        \fi%
     }
     \problemtextfont
 
@@ -481,33 +483,42 @@
     \s@tm@cr@s#1
     \ttfamily\obeylines\obeyspaces\frenchspacing
     \newcommand{\exmp}[2]{
+        \ifdefined\NoExamples\else%
         \begin{minipage}[t]{\exmpwidinf}\rightskip=0pt plus 1fill\relax##1\medskip\end{minipage}&
         \begin{minipage}[t]{\exmpwidouf}\rightskip=0pt plus 1fill\relax##2\medskip\end{minipage}\\
         \hline
+        \fi%
     }
 
     \newcommand{\exmpfile}[2]{
+       \ifdefined\NoExamples\else%
        \exmp{
           \verbatiminput{##1}
        }{
           \verbatiminput{##2}
        }%
+       \fi%
     }
 
 
+    \ifdefined\NoExamples\else%
     \begin{tabular}{|l|l|}
         \hline
         \multicolumn{1}{|c|}{\bf\texttt{\InputFileName}}&
         \multicolumn{1}{|c|}{\bf\texttt{\OutputFileName}}\\
         \hline
+    \fi%
 }{
+    \ifdefined\NoExamples\else%
     \end{tabular}
+    \fi%
 }
 
 \newenvironment{examplewide}[1][]{%
     \s@tm@cr@s#1
     \ttfamily\obeylines\obeyspaces\frenchspacing
     \newcommand{\exmp}[2]{
+        \ifdefined\NoExamples\else%
         \begin{tabular}{|c|}
         \hline
         \multicolumn{1}{|c|}{\bf\texttt{\InputFileName}}\\
@@ -523,13 +534,16 @@
         \medskip\end{minipage}\\%
         \hline
         \end{tabular}
+        \fi%
     }
     \newcommand{\exmpfile}[2]{
+       \ifdefined\NoExamples\else%
        \exmp{
           \verbatiminput{##1}
        }{
           \verbatiminput{##2}
        }%
+       \fi%
     }
 }{
 }
@@ -538,13 +552,16 @@
     \s@tm@cr@s#1
     \ttfamily\obeylines\obeyspaces\frenchspacing
     \newcommand{\exmp}[3]{
+        \ifdefined\NoExamples\else%
         \begin{minipage}[t]{\exmpthreewidinf}\rightskip=0pt plus 1fill\relax##1\medskip\end{minipage}&
         \begin{minipage}[t]{\exmpthreewidouf}\rightskip=0pt plus 1fill\relax##2\medskip\end{minipage}&
         \begin{minipage}[t]{\exmpthreewidnote}\rightskip=0pt plus 1fill\relax##3\medskip\end{minipage}\\
         \hline
+        \fi%
     }
 
     \newcommand{\exmpfile}[3]{
+       \ifdefined\NoExamples\else%
        \exmp{
           \verbatiminput{##1}
        }{
@@ -552,17 +569,22 @@
        }{
           ##3
        }%
+       \fi%
     }
 
 
+    \ifdefined\NoExamples\else%
     \begin{tabular}{|l|l|l|}
         \hline
         \multicolumn{1}{|c|}{\bf\texttt{\InputFileName}}&
         \multicolumn{1}{|c|}{\bf\texttt{\OutputFileName}}&
         \multicolumn{1}{|c|}{\bf\texttt{\expandafter\unexpanded{\expandafter\kwExampleNotes}}}\\
         \hline
+    \fi%
 }{
+    \ifdefined\NoExamples\else%
     \end{tabular}
+    \fi%
 }
 
 % -- This is hack to make feedback argument optional

--- a/statements/olymp.sty
+++ b/statements/olymp.sty
@@ -267,6 +267,17 @@
 \nopagebreak\par\afterproblemsectioncaption}
 }
 
+\newcommand{\createsectionexample}{\@newsectionexample}
+
+\def\@newsectionexample#1#2{\DeclareRobustCommand{#1}{
+\ifdefined\NoExamples\else%
+{\beforeproblemsectioncaption\noindent\bf\problemsectionfont
+\textsf{#2}}
+\nopagebreak\par\afterproblemsectioncaption%
+\fi%
+}
+}
+
 \newcommand{\createsectionpar}{\@newsectionpar}
 
 \def\@newsectionpar#1#2{\DeclareRobustCommand{#1}[1]{
@@ -287,8 +298,8 @@
 \createsection{\Interaction}{\kw@Interaction}
 \createsection{\InputFile}{\kw@Input}
 \createsection{\OutputFile}{\kw@Output}
-\createsection{\Example}{\kw@Example}
-\createsection{\Examples}{\kw@Examples}
+\createsectionexample{\Example}{\kw@Example}
+\createsectionexample{\Examples}{\kw@Examples}
 \createsection{\Explanation}{\kw@Explanation}
 \createsection{\Explanations}{\kw@Explanations}
 \createsection{\Illustration}{\kw@Illustration}

--- a/statements/olymp.sty
+++ b/statements/olymp.sty
@@ -403,7 +403,9 @@
     {
         \noindent
         \refstepcounter{problem}
-        \textbf{\problemheadfont\textsf{\kw@Problem\ \if@arabic\arabic{problem}\else\Alph{problem}\fi.\ #1%
+        \textbf{\problemheadfont\textsf{%
+                \ifdefined\ShortProblemTitle\else{\kw@Problem\ \if@arabic\arabic{problem}\else\Alph{problem}\fi.\ }\fi%
+                #1%
                 \ifdefined\DivisionNumber%
                 \if\DivisionNumber2%
                 {\ \textit{(Division\ \DivisionNumber)}}%

--- a/statements/olymp.sty
+++ b/statements/olymp.sty
@@ -438,22 +438,26 @@
             \ifdisplayorigin%
             \kw@ProblemOrigin & \thisproblemorigin \\
             \fi%
+            \ifdefined\NoInputFileName\else%
             \ifx&#2&%
             \else%
             \kw@InputFileName & \texttt{#2} \\
-            \fi%
+            \fi\fi%
+            \ifdefined\NoOutputFileName\else%
             \ifx&#3&%
             \else%
             \kw@OutputFileName & \texttt{#3} \\
-            \fi%
+            \fi\fi%
+            \ifdefined\NoTimeLimit\else%
             \ifx&#4&%
             \else%
             \kw@TimeLimit & #4 \\
-            \fi%
+            \fi\fi%
+            \ifdefined\NoMemoryLimit\else%
             \ifx&#5&%
             \else%
             \kw@MemoryLimit & #5 \\
-            \fi%
+            \fi\fi%
 %            \kw@MemoryLimit & \@memorylimit \\
             \@feedback
             \end{tabular}

--- a/statements/r_standalone.sh
+++ b/statements/r_standalone.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# DOPDFLATEX=true means compiling via pdflatex; false means latex + dvipdfm
+export DOPDFLATEX=true
+
+function doit()
+{
+  if $DOPDFLATEX ; then
+    pdflatex $1.tex || exit 1
+    pdflatex $1.tex || exit 1
+  else
+    latex $1.tex || exit 1
+    latex $1.tex || exit 1
+    dvips -t a4 $1.dvi || exit 1
+    dvipdfmx -p a4 $1 || exit 1
+  fi
+}
+
+doit standalone

--- a/statements/standalone.tex
+++ b/statements/standalone.tex
@@ -1,0 +1,56 @@
+\documentclass[12pt,a4paper,oneside]{article}
+
+\usepackage[T2A]{fontenc}
+\usepackage[utf8]{inputenc}
+\usepackage[english,russian]{babel}
+\usepackage{olymp}
+\usepackage{graphicx}
+\usepackage{amsmath}
+\usepackage{amssymb}
+\usepackage{color} % for colored text
+\usepackage{import} % for changing current dir
+\usepackage{epigraph}
+\usepackage{daytime} % for displaying version number and date
+\usepackage{wrapfig} % for having text alongside pictures
+\usepackage{verbatim}
+
+\newcommand{\importproblem}[1]{\import{../problems/#1/statement/}{./#1.en.tex}}
+
+\contest
+{ACM International Collegiate Programming Contest}%
+{Example Statements}%
+{Weekday, Month Day, Year}%
+
+% Vertical strecth for page: http://tex.stackexchange.com/a/21207
+\iftrue
+  \makeatletter
+  \usepackage[active,tightpage,psfixbb]{preview}
+  \renewcommand{\PreviewBorder}{1cm}
+
+  \newenvironment{stretchpage}%
+    {\begin{preview}\begin{minipage}{\hsize}}%
+    {\end{minipage}\end{preview}}
+  \AtBeginDocument{\begin{stretchpage}}
+  \AtEndDocument{\end{stretchpage}}
+
+  \newcommand{\@@newpage}{\end{stretchpage}\begin{stretchpage}}
+
+  \let\@real@section\section
+  \renewcommand{\section}{\@@newpage\@real@section}
+  \makeatother
+\fi
+
+% Problem title without problem letter:
+\def\ShortProblemTitle{}
+
+\binoppenalty=10000
+\relpenalty=10000
+\exhyphenpenalty=10000
+
+\begin{document}
+
+\raggedbottom
+
+\importproblem{arithmetic}
+
+\end{document}

--- a/statements/standalone.tex
+++ b/statements/standalone.tex
@@ -45,9 +45,6 @@
 \def\NoProblemHead{}
 \def\NoExamples{}
 
-\def\Example{}
-\def\Examples{}
-
 \binoppenalty=10000
 \relpenalty=10000
 \exhyphenpenalty=10000

--- a/statements/standalone.tex
+++ b/statements/standalone.tex
@@ -44,6 +44,10 @@
 \def\ShortProblemTitle{}
 \def\NoProblemHead{}
 \def\NoExamples{}
+%\def\NoInputFileName{}
+%\def\NoOutputFileName{}
+%\def\NoTimeLimit{}
+%\def\NoMemoryLimit{}
 
 \binoppenalty=10000
 \relpenalty=10000

--- a/statements/standalone.tex
+++ b/statements/standalone.tex
@@ -42,6 +42,11 @@
 
 % Problem title without problem letter:
 \def\ShortProblemTitle{}
+\def\NoProblemHead{}
+\def\NoExamples{}
+
+\def\Example{}
+\def\Examples{}
 
 \binoppenalty=10000
 \relpenalty=10000


### PR DESCRIPTION
Ability to compile stripped-down version of a statement.
Useful for embedding the statement text into a page where problem name, ID, I/O mode, time/memory limits, and examples may be already specified by a contest system.

* \def\NoProblemHead{} - no problem header at all
* * \def\ShortProblemTitle{} - no problem name line in header
* * \def\NoInputFileName{} - no input file line in header
* * \def\NoOutputFileName{} - no output file line in header
* * \def\NoTimeLimit{} - no time limit in header
* * \def\NoMemoryLimit{} - no memory limit in header
* \def\NoExamples{} - no examples
