### PR TITLE
hyperref package compatibility fix.

### DIFF
--- a/statements/olymp.sty
+++ b/statements/olymp.sty
@@ -91,10 +91,11 @@
 % -- End of setup margins --
 
 %---------- From package "lastpage" ------------------
-\def\lastpage@putlabel{\addtocounter{page}{-1}%
+\@ifundefined{lastpage@putl@bel}{
+\def\lastpage@putl@bel{\addtocounter{page}{-1}%
    \immediate\write\@auxout{\string\newlabel{LastPage}{{}{\thepage}}}%
-   \addtocounter{page}{1}}
-\AtEndDocument{\clearpage\lastpage@putlabel}%
+   \addtocounter{page}{1}}}
+\AtEndDocument{\clearpage\lastpage@putl@bel}%
 %---------- end of "lastpage" ------------------
 
 % -- Setup sizes --


### PR DESCRIPTION
The `\lastpage@putlabel` was replaced by conditional definition of `\lastpage@putl@bel`, as proposed by the section _3.13. Other packages manipulating `\lastpage@putlabel`_ of the `lastpage` package [documentation](https://mirror.lyrahosting.com/CTAN/macros/latex/contrib/lastpage/lastpage.pdf).