### PR TITLE
Lastpage (and hyperref) package compatibility fix

### DIFF
--- a/statements/example-lastpage-hyperref.tex
+++ b/statements/example-lastpage-hyperref.tex
@@ -1,0 +1,12 @@
+\documentclass[11pt,a4paper,oneside]{article}
+
+\usepackage{olymp}
+\usepackage{lastpage}
+\usepackage{hyperref}
+
+\hypersetup{colorlinks=true}
+
+\begin{document}
+This example uses both \href{https://ctan.org/pkg/lastpage}{lastpage},
+and \href{https://ctan.org/pkg/hyperref}{hyperref} packages.
+\end{document}

--- a/statements/example-lastpage.tex
+++ b/statements/example-lastpage.tex
@@ -1,0 +1,8 @@
+\documentclass[11pt,a4paper,oneside]{article}
+
+\usepackage{olymp}
+\usepackage{lastpage}
+
+\begin{document}
+This example uses \texttt{lastpage} package only.
+\end{document}

--- a/statements/example-no-lastpage.tex
+++ b/statements/example-no-lastpage.tex
@@ -1,0 +1,7 @@
+\documentclass[11pt,a4paper,oneside]{article}
+
+\usepackage{olymp}
+
+\begin{document}
+This example does not use neither \texttt{lastpage} nor \texttt{hyperref} packages.
+\end{document}

--- a/statements/olymp.sty
+++ b/statements/olymp.sty
@@ -90,12 +90,14 @@
 
 % -- End of setup margins --
 
+\@ifundefined{lastpage@putlabel}{
 %---------- From package "lastpage" ------------------
 \def\lastpage@putlabel{\addtocounter{page}{-1}%
    \immediate\write\@auxout{\string\newlabel{LastPage}{{}{\thepage}}}%
    \addtocounter{page}{1}}
 \AtEndDocument{\clearpage\lastpage@putlabel}%
 %---------- end of "lastpage" ------------------
+}%
 
 % -- Setup sizes --
 \newlength{\exmpwidinf}


### PR DESCRIPTION
Disables a `lastpage` compatibility shim when the actual [lastpage](https://ctan.org/pkg/lastpage) package is present. 

This change seems to be useless per se, but the `lastpage` package, in turn, provides compatibility shims for other packages, such as [hyperref](https://ctan.org/pkg/hyperref), thus allowing their usage.

Both `lastpage` and `hyperref` usage examples added. Feel free to move them to the appropriate place, if any.