### PR TITLE
Extra spaces for header and footer rules fix

### DIFF
--- a/statements/example-rule.tex
+++ b/statements/example-rule.tex
@@ -1,0 +1,9 @@
+\documentclass[11pt,a4paper,oneside]{article}
+
+\usepackage{olymp}
+\usepackage{color}
+
+\begin{document}
+~\vspace{-3ex}
+{\color{blue}\hrule{}E\hfill{}E}
+\end{document}

--- a/statements/olymp.sty
+++ b/statements/olymp.sty
@@ -650,7 +650,7 @@
 
 \makeatletter
 
-\renewcommand{\@oddhead}{
+\renewcommand{\@oddhead}{%
     \parbox{\textwidth}{
         \sffamily
         \begin{center}
@@ -661,8 +661,8 @@
     }
 }
 
-\renewcommand{\@oddfoot}{
-\gdef\problemletter{\if@arabic\arabic{problem}\else\Alph{problem}\fi}
+\renewcommand{\@oddfoot}{%
+\gdef\problemletter{\if@arabic\arabic{problem}\else\Alph{problem}\fi}%
 
 % Revision signature
 \ifrevisionsignature%


### PR DESCRIPTION
Removes extra spaces to left or header and footer rules, that caused slight misalignment of these rules to the rest of the page.

Before this change (a black rule is the header's rule, a blue rule and `E`-s are the page content): ![before](https://user-images.githubusercontent.com/2034687/147743974-88022ec4-4c23-4968-929d-233d75ecc476.png)

After this change: ![after](https://user-images.githubusercontent.com/2034687/147743971-c2023391-e68e-4e16-8c1a-3dec5f7f840f.png)

The example file added. Feel free to move it to the proper place, if needed.
